### PR TITLE
add all "extras"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,36 @@
 # Gedit Markdown Preview
 
 ## Install
+This plugin depends on the `python3-markdown` package (install via your preferred method)
 
 ```sh
 mkdir -p ~/.local/share/gedit/plugins/
 cd ~/.local/share/gedit/plugins/
 git clone https://github.com/aliva/gedit-markdownpreview.git markdownpreview
 ```
-
-You need to install `python3-markdown` for this plugin.
+Optionally install `pymdown-extensions` for extra utility with:   
+`pip3 install pymdown-extensions`
 
 Tested on gedit 3.30.2
+
+## Features:
+This plugin supports standard Markdown, plus:
+- [Code Highlighting](https://python-markdown.github.io/extensions/code_hilite/)
+- [Abbreviations](https://python-markdown.github.io/extensions/abbreviations/)
+- [Attribute Lists](https://python-markdown.github.io/extensions/attr_list/)
+- [Definition Lists](https://python-markdown.github.io/extensions/definition_lists/)
+- [Fenced Code Blocks](https://python-markdown.github.io/extensions/fenced_code_blocks/)
+- [Footnotes](https://python-markdown.github.io/extensions/footnotes/)
+- [Tables](https://python-markdown.github.io/extensions/tables/)
+
+With 0ptional `pymdown-extensions` support:   
+- [Caret](https://facelessuser.github.io/pymdown-extensions/extensions/caret/) superscripting
+- [Better Emphasis](https://facelessuser.github.io/pymdown-extensions/extensions/betterem/) for bold, itallic, and underscore
+- [SuperFences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/) Improved Fenced Code Blocks
+- [extrarawHTML](https://facelessuser.github.io/pymdown-extensions/extensions/extrarawhtml/) to Parse MD inside HTML blocks
+- [Mark](https://facelessuser.github.io/pymdown-extensions/extensions/mark/) for simple highlighting
+- [Task Lists](https://facelessuser.github.io/pymdown-extensions/extensions/tasklist/)
+- [Tilde](https://facelessuser.github.io/pymdown-extensions/extensions/tilde/) for subscripting and strikethrough
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This plugin supports standard Markdown, plus:
 - [Footnotes](https://python-markdown.github.io/extensions/footnotes/)
 - [Tables](https://python-markdown.github.io/extensions/tables/)
 
-With 0ptional `pymdown-extensions` support:   
+With optional `pymdown-extensions`:   
 - [Caret](https://facelessuser.github.io/pymdown-extensions/extensions/caret/) superscripting
 - [Better Emphasis](https://facelessuser.github.io/pymdown-extensions/extensions/betterem/) for bold, itallic, and underscore
 - [SuperFences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/) Improved Fenced Code Blocks

--- a/markdownpreview.py
+++ b/markdownpreview.py
@@ -1,6 +1,8 @@
 import os
 from string import Template
 
+import importlib.util
+
 import gi
 from markdown import markdown
 from markdown.extensions import Extension
@@ -149,20 +151,40 @@ class MarkdownPreviewWindowActivatable(GObject.Object, Gedit.WindowActivatable):
             buffer.get_end_iter(),
             True,
         )
-        html = markdown(
-            text,
-            extensions=[
-                'extra',
-                'codehilite',
-                AutoDirectionExtension(),
-            ],
-            extension_configs={
-                'codehilite': {
-                    'linenums': False,
-                    'noclasses': True,
+        if importlib.util.find_spec('pymdownx') is not None:
+            html = markdown(
+                text,
+                extensions=[
+                    'pymdownx.caret',
+                    'pymdownx.extra',
+                    'pymdownx.mark',
+                    'pymdownx.tasklist',
+                    'pymdownx.tilde',
+                    'codehilite',
+                    AutoDirectionExtension(),
+                ],
+                extension_configs={
+                    'codehilite': {
+                        'linenums': False,
+                        'noclasses': True,
+                    }
                 }
-            }
-        )
+            )
+        else:
+            html = markdown(
+                text,
+                extensions=[
+                    'extra',
+                    'codehilite',
+                    AutoDirectionExtension(),
+                ],
+                extension_configs={
+                    'codehilite': {
+                        'linenums': False,
+                        'noclasses': True,
+                    }
+                }
+            )
         html = Template(self.html_template).substitute(
             content=html,
             style=self.style_template,

--- a/markdownpreview.py
+++ b/markdownpreview.py
@@ -152,9 +152,8 @@ class MarkdownPreviewWindowActivatable(GObject.Object, Gedit.WindowActivatable):
         html = markdown(
             text,
             extensions=[
+                'extra',
                 'codehilite',
-                'fenced_code',
-                'tables',
                 AutoDirectionExtension(),
             ],
             extension_configs={


### PR DESCRIPTION
Small change to include the Python-Markdown "extras" extensions by default, instead of loading them one at a time. Extra and all its supported extensions are included in the standard Markdown library.